### PR TITLE
Extending the excludes/warns format + fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ When vulnerabilities are found, `owdit` prints out a pretty-formatted report.
 The exit code of `owdit` is the number of found vulnerabilities or _-1_ on error.
 
 ##### Ignoring vulnerabilities in specific packages
-When desirable, one can specify packages to be excluded from owdit's check in a `.owditrc` file in the same folder as `package.json`:
+When desirable, one can specify packages with or without a version number to be excluded from owdit's check in a `.owditrc` file in the same folder as `package.json`:
 
 ```json
 {
-  "excludes": [ "foo", "bar" ],
+  "excludes": [ "foo", "bar", "woot@3.5.4" ],
   "warns": [ "baz" ]
 }
 ```

--- a/lib/owdit.js
+++ b/lib/owdit.js
@@ -153,6 +153,8 @@ function check(cwd, callback) {
       headers: {"Content-Type": "application/json"}
     };
     const request = client.post("https://ossindex.net/v2.0/package", restOptions, (data, response) => {
+      // This will send the error from oss indes back to the consumer if they are having problems or if the servers are down
+      // For example: If they are doing server maintence
       if(response.statusCode >= 500) {
         callback(data.toString());
       } else {

--- a/lib/owdit.js
+++ b/lib/owdit.js
@@ -121,10 +121,10 @@ function check(cwd, callback) {
     const deps = Object.keys(dependencies);
 
     deps.forEach((dependency) => {
+      const dependent = dependencies[dependency];
       if (excludes.includes(dependency) || excludes.includes(`${dependency}@${dependent.version}`)) {
         return;
       }
-      const dependent = dependencies[dependency];
       const key = dependency + dependent.version;
 
       if (!registerModules.hasOwnProperty(key)) {

--- a/lib/owdit.js
+++ b/lib/owdit.js
@@ -96,7 +96,7 @@ function check(cwd, callback) {
   });
 
   if (result.status !== 0) {  //eslint-disable-line no-magic-numbers
-    return callback(new Error(`Error running npm ls: ${result.stderr}`));
+	console.error(`Error running npm ls: ${result.stderr}`);
   }
   let packages = [];
 
@@ -135,7 +135,7 @@ function check(cwd, callback) {
         list.push({
           pm:      "npm",
           name:    dependency,
-          version: dependent.version
+          version: dependent.version || dependent.required.version
         });
         if (dependent.dependencies) {
           list.push(...flattenDependencies(path, dependent.dependencies));
@@ -152,40 +152,44 @@ function check(cwd, callback) {
       data:    flatList,
       headers: {"Content-Type": "application/json"}
     };
-    const request = client.post("https://ossindex.net/v2.0/package", restOptions, (data) => {
-      let numVulnerabilitiesFails = 0;   //eslint-disable-line no-magic-numbers
-      let numVulnerabilitiesWarns = 0;   //eslint-disable-line no-magic-numbers
-      const vulnerablePackages = data.filter((element) => {
-        if (warns.includes(element.name)) {
-          numVulnerabilitiesWarns += element["vulnerability-matches"];
-        } else {
-          numVulnerabilitiesFails += element["vulnerability-matches"];
-        }
+    const request = client.post("https://ossindex.net/v2.0/package", restOptions, (data, response) => {
+      if(response.statusCode >= 500) {
+        callback(data.toString());
+      } else {
+        let numVulnerabilitiesFails = 0;   //eslint-disable-line no-magic-numbers
+        let numVulnerabilitiesWarns = 0;   //eslint-disable-line no-magic-numbers
+        const vulnerablePackages = data.filter((element) => {
+          if (warns.includes(element.name) || warns.includes(`${element.name}@${element.version}`)) {
+            numVulnerabilitiesWarns += element["vulnerability-matches"];
+          } else {
+            numVulnerabilitiesFails += element["vulnerability-matches"];
+          }
 
-        return element["vulnerability-matches"] > 0;  //eslint-disable-line no-magic-numbers
-      }).map((element) => {
-        return {
-          name:            element.name,
-          warnOnly:        warns.includes(element.name) || warns.includes(`${element.name}@${element.version}`),
-          version:         element.version,
-          path:            registerModules[`${element.name}${element.version}`].path,
-          vulnerabilities: element.vulnerabilities.map((element) => {
-            return {
-              title:       element.title,
-              description: element.description,
-              versions:    element.versions,
-              references:  element.references
-            };
-          })
+          return element["vulnerability-matches"] > 0;  //eslint-disable-line no-magic-numbers
+        }).map((element) => {
+          return {
+           name:            element.name,
+           warnOnly:        warns.includes(element.name) || warns.includes(`${element.name}@${element.version}`),
+           version:         element.version,
+           path:            registerModules[`${element.name}${element.version}`].path,
+           vulnerabilities: element.vulnerabilities.map((element) => {
+              return {
+                title:       element.title,
+                description: element.description,
+                versions:    element.versions,
+                references:  element.references
+              };
+            })
+          };
+        });
+        const vulnerabilityReport = {
+          vulnerabilityFailCount: numVulnerabilitiesFails,
+          vulnerabilityWarnCount: numVulnerabilitiesWarns,
+          vulnerablePackages:     vulnerablePackages
         };
-      });
-      const vulnerabilityReport = {
-        vulnerabilityFailCount: numVulnerabilitiesFails,
-        vulnerabilityWarnCount: numVulnerabilitiesWarns,
-        vulnerablePackages:     vulnerablePackages
-      };
 
-      return callback(null, vulnerabilityReport);
+        return callback(null, vulnerabilityReport);
+      }
     });
 
     return request.on("error", callback);

--- a/lib/owdit.js
+++ b/lib/owdit.js
@@ -121,7 +121,7 @@ function check(cwd, callback) {
     const deps = Object.keys(dependencies);
 
     deps.forEach((dependency) => {
-      if (excludes.includes(dependency)) {
+      if (excludes.includes(dependency) || excludes.includes(`${dependency}@${dependent.version}`)) {
         return;
       }
       const dependent = dependencies[dependency];
@@ -166,7 +166,7 @@ function check(cwd, callback) {
       }).map((element) => {
         return {
           name:            element.name,
-          warnOnly:        warns.includes(element.name),
+          warnOnly:        warns.includes(element.name) || warns.includes(`${element.name}@${element.version}`),
           version:         element.version,
           path:            registerModules[`${element.name}${element.version}`].path,
           vulnerabilities: element.vulnerabilities.map((element) => {


### PR DESCRIPTION
This PR extends the excludes/warns format to also support package@version syntax. Additionally I fixed a bug which blocked the tool from running if you have an invalid peer dependency (there are valid use cases where this is OK). I also added some logic to send the error message from ossindex to the console if a 500 error happens when requesting data